### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "shinji <dotneet@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "async-chain-proxy": "^0.1.3",
+    "async-chain-proxy": "^0.1.2",
     "chrome-launcher": "^0.1.2",
     "chrome-remote-interface": "^0.23.2",
     "sharp": "^0.18.1",


### PR DESCRIPTION
Fix #12 since `async-chain-proxy` most recent published version is `0.1.2`