### PR TITLE
Fix JSON stringify error when waiting for selector

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -252,9 +252,7 @@ class Document {
               reject(new WaitTimeoutError('wait() timeout'))
               return
             }
-            const result = await this._evaluateWithReplaces(() => {
-              return document.querySelector('?')
-            }, {}, {'?': escapeSingleQuote(selector)})
+            const result = await this.exists(selector)
             if (result) {
               resolve(result)
             } else {


### PR DESCRIPTION
We shouldn't be JSON.stringify'ing DOM node collections as it's possible to raise the following error (in the case of React):

"TypeError: Converting circular structure to JSON".